### PR TITLE
fix(monitoring): align blackbox values with chart config schema

### DIFF
--- a/monitoring/blackbox-values.yaml
+++ b/monitoring/blackbox-values.yaml
@@ -1,11 +1,10 @@
-modules:
-  https_2xx:
-    prober: http
-    timeout: 10s
-    http:
-      method: GET
-      valid_status_codes: [200]
-      headers:
-        Host: pccs.example.com  # Replace with $PCCS_URL
-      tls_config:
-        insecure_skip_verify: false
+config:
+  modules:
+    http_2xx:
+      prober: http
+      timeout: 10s
+      http:
+        method: GET
+        valid_status_codes: [200]
+        tls_config:
+          insecure_skip_verify: true

--- a/monitoring/prometheus-probe.yaml
+++ b/monitoring/prometheus-probe.yaml
@@ -32,7 +32,7 @@ spec:
   jobName: pccs
   prober:
     url: http://blackbox-exporter-prometheus-blackbox-exporter.monitoring.svc:9115
-  module: https_2xx
+  module: http_2xx
   targets:
     staticConfig:
       static:


### PR DESCRIPTION
This PR fixes the blackbox monitoring configuration reported in #14.

  ### Changes
  - Update `monitoring/blackbox-values.yaml` to use the chart-expected root structure:
    - `config.modules.http_2xx` (instead of top-level `modules.https_2xx`)
  - Remove the optional `headers` block (`Host`) from the probe config.
  - Set `tls_config.insecure_skip_verify: true` for the module.
  - Align `monitoring/prometheus-probe.yaml` to use `module: http_2xx`.